### PR TITLE
Define and make things via a factory

### DIFF
--- a/lib/tdb.js
+++ b/lib/tdb.js
@@ -1,5 +1,3 @@
-var definitions = {}
-
 const tdb = () => new Factory()
 
 class Factory {

--- a/lib/tdb.js
+++ b/lib/tdb.js
@@ -1,25 +1,27 @@
 var definitions = {}
 
-const tdb = {}
+const tdb = () => new Factory()
 
-tdb.make = (typeToMake, explicitProperties) => {
-  var definition = definitions[typeToMake.name]
-  if (!definition) {
-    throw new UndefinedError(typeToMake.name)
+class Factory {
+  constructor() {
+    this._definitions = {}
   }
-  var object = definition.buildInstance()
-  definition.getDefaultProperties().merge(explicitProperties).assignTo(object)
-  return object
-}
-tdb.make.a = tdb.make
 
-tdb.define = (typeToDefine, properties) => {
-  return definitions[typeToDefine.name] = new Definition(typeToDefine).setDefaultProperties(properties)
-}
+  make(typeToMake, explicitProperties) {
+    var definition = this._definitions[typeToMake.name]
+    if (!definition) {
+      throw new UndefinedError(typeToMake.name)
+    }
+    var object = definition.buildInstance()
+    definition.getDefaultProperties().merge(explicitProperties).assignTo(object)
+    return object
+  }
 
-// Used for our own testing. Should not be needed by regular users.
-tdb._reset = () => {
-  definitions = {}
+  define(typeToDefine, properties) {
+    const definition = new Definition(typeToDefine).setDefaultProperties(properties)
+    this._definitions[typeToDefine.name] = definition
+    return definition
+  }
 }
 
 class UndefinedError extends Error {

--- a/test/tdb_test.js
+++ b/test/tdb_test.js
@@ -5,8 +5,10 @@ const make = tdb.make
 const define = tdb.define
 
 describe('tdb', () => {
+  let factory
+
   beforeEach(function () {
-    tdb._reset()
+    factory = tdb()
   })
 
   class ThingToMake {
@@ -18,13 +20,13 @@ describe('tdb', () => {
   context('default properties', () => {
 
     beforeEach(() => {
-      define(ThingToMake, {
+      factory.define(ThingToMake, {
         name: "Nemo"
       })
     })
 
     it('uses default property values if no properties specified', () => {
-      var madeThing = make.a(ThingToMake)
+      var madeThing = factory.make(ThingToMake)
       expect(madeThing.name).to.equal('Nemo')
     })
 
@@ -33,13 +35,13 @@ describe('tdb', () => {
   context('explicit properties', () => {
 
     beforeEach(() => {
-      define(ThingToMake, {
+      factory.define(ThingToMake, {
         name: "Nemo"
       })
     })
 
     it('overrides default values with explicit properties', () => {
-      var madeThing = make.a(ThingToMake, { name: "Dave" })
+      var madeThing = factory.make(ThingToMake, { name: "Dave" })
       expect(madeThing.name).to.equal('Dave')
     })
 
@@ -48,13 +50,13 @@ describe('tdb', () => {
   context('lazy default properties', () => {
 
     beforeEach(() => {
-      define(ThingToMake, {
+      factory.define(ThingToMake, {
         name: () => { return 'Lazy name' }
       })
     })
 
     it('uses the evaluated lazy default property value when no properties specified', () => {
-      var madeThing = make.a(ThingToMake)
+      var madeThing = factory.make(ThingToMake)
       expect(madeThing.name).to.equal('Lazy name')
     })
   })
@@ -62,16 +64,16 @@ describe('tdb', () => {
   context('sequences', () => {
 
     beforeEach(() => {
-      define(ThingToMake, {
+      factory.define(ThingToMake, {
         name: (n) => { return `Thing name ${n}` }
       })
     })
 
     it('increments the sequence number each time it builds', () => {
-      var madeThingOne = make.a(ThingToMake)
+      var madeThingOne = factory.make(ThingToMake)
       expect(madeThingOne.name).to.equal('Thing name 1')
 
-      var madeThingTwo = make.a(ThingToMake)
+      var madeThingTwo = factory.make(ThingToMake)
       expect(madeThingTwo.name).to.equal('Thing name 2')
     })
   })
@@ -87,16 +89,16 @@ describe('tdb', () => {
     }
 
     it('uses the defined constructor arguments when given', () => {
-      define(ValidatedThingToMake).constructWith({ name: 'Constructed name' })
-      var madeThing = make.a(ValidatedThingToMake)
+      factory.define(ValidatedThingToMake).constructWith({ name: 'Constructed name' })
+      var madeThing = factory.make(ValidatedThingToMake)
       expect(madeThing.name).to.equal('Constructed name')
     })
 
     it('can use sequences in constructor arguments', () => {
-      define(ValidatedThingToMake).constructWith({ 
+      factory.define(ValidatedThingToMake).constructWith({
         name: (n) => `Constructed name ${n}`
       })
-      var madeThing = make.a(ValidatedThingToMake)
+      var madeThing = factory.make(ValidatedThingToMake)
       expect(madeThing.name).to.equal('Constructed name 1')
     })
   })
@@ -107,7 +109,7 @@ describe('tdb', () => {
     var UndefinedError = tdb.Errors.UndefinedError
 
     it("it raises an error when asked to make a type that hasn't been defined", () => {
-      expect(() => { make.a(NewThingToMake) }).to.throw(UndefinedError, 
+      expect(() => { factory.make(NewThingToMake) }).to.throw(UndefinedError,
         'Please use `define` to specify default attributes for a NewThingToMake, before attempting to make one.')
     })
   })


### PR DESCRIPTION
Hey @mattwynne, I like this thing.

Instead of exporting `.make()` and `.define()` functions, I think it makes sense for the module to return a new factory each time it's called, which encapsulates a particular set of definitions. That way there is nothing to `reset()` as well... What do you think? 